### PR TITLE
add profile setup flow and fb listeners

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,38 +1,85 @@
 import firebase from 'firebase'
 import { routerActions } from 'react-router-redux'
 
-import { firebaseAuth } from '../firebase'
+import { firebaseAuth, firebasePlayers } from '../firebase'
+import { isNewUser } from '../utils'
 
 // action types
-export const SIGN_IN_ERROR = 'SIGN_IN_ERROR'
 export const SIGN_IN_SUCCESS = 'SIGN_IN_SUCCESS'
+export const SIGN_IN_ERROR = 'SIGN_IN_ERROR'
 export const SIGN_OUT_SUCCESS = 'SIGN_OUT_SUCCESS'
+export const SETUP_NEW_USER_SUCCESS = 'SETUP_NEW_USER_SUCCESS'
+export const SETUP_NEW_USER_ERROR = 'SETUP_NEW_USER_ERROR'
+export const SET_USER_PROFILE_SUCCESS = 'SET_USER_PROFILE_SUCCESS'
+export const SET_USER_PROFLE_ERROR = 'SET_USER_PROFILE_ERROR'
+export const UPDATE_USER_PROFILE_SUCCESS = 'UPDATE_USER_PROFILE_SUCCESS'
+export const UPDATE_USER_PROFILE_ERROR = 'UPDATE_USER_PROFILE_FAILURE'
+export const WATCH_USER_PROFILE_SUCCESS = 'WATCH_USER_PROFILE_SUCCESS'
+export const WATCH_USER_PROFILE_ERROR = 'WATCH_USER_PROFILE_ERROR'
+export const UNWATCH_USER_PROFILE_SUCCESS = 'UNWATCH_USER_PROFILE_SUCCESS'
+export const UNWATCH_USER_PROFILE_ERROR = 'UNWATCH_USER_PROFILE_ERROR'
 
-export const signInError = (err) => ({
-  type: SIGN_IN_ERROR,
-  payload: err,
-})
-
-export const signInSuccess = ({ user }) => ({
+// action creators
+export const signInSuccess = user => ({
   type: SIGN_IN_SUCCESS,
   payload: user,
 })
 
-export const authenticate = (provider) => {
-  return async dispatch => {
-    try {
-      const data = await firebaseAuth.signInWithPopup(provider)
-      dispatch(signInSuccess(data))
-      dispatch(routerActions.push('/'))
-    } catch (err) {
-      console.error(`Error authenticating: ${err}`)
-      dispatch(signInError(err))
-    }
-  }
-}
+export const signInError = err => ({
+  type: SIGN_IN_ERROR,
+  payload: err,
+})
 
 export const signOutSuccess = () => ({
   type: SIGN_OUT_SUCCESS,
+})
+
+export const setupNewUserSuccess = () => ({
+  type: SETUP_NEW_USER_SUCCESS,
+})
+
+export const setupNewUserError = err => ({
+  type: SETUP_NEW_USER_ERROR,
+  payload: err,
+})
+
+export const setUserProfileSuccess = profile => ({
+  type: SET_USER_PROFILE_SUCCESS,
+  payload: profile,
+})
+
+export const setUserProfileError = err => ({
+  type: SET_USER_PROFLE_ERROR,
+  payload: err,
+})
+
+export const updateUserProfileSuccess = profile => ({
+  type: UPDATE_USER_PROFILE_SUCCESS,
+  payload: profile,
+})
+
+export const updateUserProfileError = err => ({
+  type: UPDATE_USER_PROFILE_ERROR,
+  payload: err,
+})
+
+export const watchUserProfileSuccess = profileUpdateCallback => ({
+  type: WATCH_USER_PROFILE_SUCCESS,
+  payload: profileUpdateCallback,
+})
+
+export const watchUserProfileError = err => ({
+  type: WATCH_USER_PROFILE_ERROR,
+  payload: err,
+})
+
+export const unwatchUserProfileSuccess = () => ({
+  type: UNWATCH_USER_PROFILE_SUCCESS,
+})
+
+export const unwatchUserProfileError = err => ({
+  type: UNWATCH_USER_PROFILE_ERROR,
+  payload: err,
 })
 
 export const signInWithGoogle = () => {
@@ -47,9 +94,121 @@ export const signInWithFacebook = () => {
   return authenticate(new firebase.auth.FacebookAuthProvider())
 }
 
-export const signOut = () => {
+// thunk actions
+export const authenticate = (provider) => {
   return async dispatch => {
-    await firebaseAuth.signOut()
-    dispatch(signOutSuccess())
+    try {
+      // authenticate
+      const data = await firebaseAuth.signInWithPopup(provider)
+      const { user } = data
+      console.log(`\n\nUSER -> ${user}\n\n`)
+      const { uid } = user         
+      dispatch(signInSuccess(user))
+      // setup newly registered users
+      if (isNewUser(user)) await dispatch(setupNewUser())
+      // get user profile
+      await dispatch(setUserProfile(uid)) 
+      // redirect to home
+      // watch user profile for changes
+      await dispatch(watchUserProfile(uid))
+    } catch (err) {
+      console.error(`Error authenticating: ${err}`)
+      dispatch(signInError(err))
+    }
+  }
+}
+
+export const signOut = () => {
+  return async (dispatch, getState) => {
+    try {
+      const { user } = getState().auth 
+      // unwatch user profile for changes
+      dispatch(unwatchUserProfile())
+      // signout 
+      await firebaseAuth.signOut()
+      dispatch(signOutSuccess())
+    } catch (err) {
+      console.erorr(`Error sigining out: ${err}`)
+    }
+  }
+}
+
+export const setUserProfile = uid => {
+  return async dispatch => {
+    try {
+      const ref = firebasePlayers.child(uid)
+      const snap = await ref.once('value')
+      const profile = snap.val()
+      dispatch(setUserProfileSuccess(profile))
+    } catch (err) {
+      console.error(`Error setting user profile: ${err}`)
+      dispatch(setUserProfileError(err))
+    }
+  }
+}
+
+export const updateUserProfile = snap => {
+  return async dispatch => {
+    try {
+      const profile = snap.val()
+      dispatch(updateUserProfileSuccess(profile))
+    } catch (err) {
+      console.error(`Error updating user profile: ${err}`)
+      dispatch(updateUserProfileError(err))
+    }
+  }
+}
+
+export const watchUserProfile = uid => {
+  return async dispatch => {
+    try {
+      // set firebase listener
+      const profileUpdateCallback = firebasePlayers.child(uid)
+        .on('child_changed', snap => dispatch(updateUserProfile(snap)))
+      dispatch(watchUserProfileSuccess(profileUpdateCallback))
+    } catch (err) {
+      console.error(`Error watching user profile: ${err}`)
+      dispatch(watchUserProfileError(err))
+    }
+  }
+}
+
+export const unwatchUserProfile = uid => {
+  return async (dispatch, getState) => {
+    try {
+      // get user uid and profileUpdateCallback
+      const { user, profileUpdateCallback } = getState().auth
+      const { uid } = user
+      // remove listener
+      firebasePlayers.child(uid).off('child_changed', profileUpdateCallback)
+      dispatch(unwatchUserProfileSuccess())
+    } catch (err) {
+      console.error(`Error unwatching user profile: ${err}`)
+      dispatch(unwatchUserProfileError(err))
+    }
+  }
+}
+
+export const setupNewUser = () => {
+  return async (dispatch, getState) => {
+    try {
+      // get relevant user data
+      const { user } = getState().auth
+      const { uid, displayName, photoURL } = user
+      // init user in players tree
+      await firebasePlayers.child(uid).set({
+        lifetimeScore: 0,
+        // have to set to false
+        // firebase does not register `null` or `undefined`
+        // would result in a no-op
+        currentGame: false,
+        displayName,
+        photoURL,
+      })
+      dispatch(setupNewUserSuccess())
+    } catch (err) {
+      console.log('Error setting up new user')
+      dispatch(setupNewUserError(err))
+    }
   }
 }

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -12,3 +12,6 @@ const config = {
 export const firebaseApp = firebase.initializeApp(config)
 export const firebaseDb = firebase.database()
 export const firebaseAuth = firebase.auth()
+export const firebasePlayers = firebase.database().ref('players')
+export const firebaseGames = firebase.database().ref('games')
+export const firebaseQueue = firebase.database().ref('queue')

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,11 +1,16 @@
 import {
   SIGN_IN_SUCCESS,
-  SIGN_OUT_SUCCESS
+  SIGN_OUT_SUCCESS,
+  SET_USER_PROFILE_SUCCESS,
+  UPDATE_USER_PROFILE_SUCCESS,
+  WATCH_USER_PROFILE_SUCCESS,
 } from '../actions/auth'
 
 export const initialState = {
   authenticated: false,
   user: null,
+  profile: null,
+  profileUpdateCallback: null,
 }
 
 export default (state = initialState, action) => {
@@ -14,8 +19,27 @@ export default (state = initialState, action) => {
     // add user to state
     case SIGN_IN_SUCCESS:
       return {
+        ...state,
         authenticated: true,
         user: payload,
+      }
+    // set user profile
+    case SET_USER_PROFILE_SUCCESS:
+      return {
+        ...state,
+        profile: payload,
+      }
+    // watch user profile
+    case WATCH_USER_PROFILE_SUCCESS:
+      return {
+        ...state,
+        profileUpdateCallback: payload,
+      }
+    // update user profile
+    case UPDATE_USER_PROFILE_SUCCESS:
+      return {
+        ...state,
+        profile: payload,
       }
     // reset state
     case SIGN_OUT_SUCCESS:

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
 export { default as ProtectedRoute } from './protected-route'
 export { default as PublicRoute } from './public-route'
 export { default as registerServiceWorker } from './register-service-worker'
+export { default as isNewUser } from './is-new-user'

--- a/src/utils/is-new-user.js
+++ b/src/utils/is-new-user.js
@@ -1,0 +1,9 @@
+export default (user) => {
+  try {
+    const { metadata } = user
+    const { creationTime, lastSignInTime } = metadata
+    return creationTime === lastSignInTime
+  } catch (err) {
+    throw new Error('Error checking if user is new')
+  }
+}

--- a/src/utils/protected-route.js
+++ b/src/utils/protected-route.js
@@ -1,19 +1,19 @@
-import React from 'react';
-import { Route } from 'react-router-dom';
+// import React from 'react';
+// import { Route } from 'react-router-dom';
 
-/**
- * @param {function|object} Component React component to render
- * @param {boolean} authed describes user auth status
- * @param {*} rest any additional parameters
- */
-export default ({ component: Component, authenticated, ...args }) => (
-    <Route
-        {...rest}
-        render={props => authenticated ?
-            // user is authorized; proceed to route
-            <Component {...props} /> :
-            // user is not authorized: proceed to login
-            <Redirect to={{pathname: '/login', state: { from: props.location}}} />
-        }
-    />
-);
+// /**
+//  * @param {function|object} Component React component to render
+//  * @param {boolean} authed describes user auth status
+//  * @param {*} rest any additional parameters
+//  */
+// export default ({ component: Component, authenticated, ...args }) => (
+//     <Route
+//         {...rest}
+//         render={props => authenticated ?
+//             // user is authorized; proceed to route
+//             <Component {...props} /> :
+//             // user is not authorized: proceed to login
+//             <Redirect to={{pathname: '/login', state: { from: props.location}}} />
+//         }
+//     />
+// );

--- a/src/utils/public-route.js
+++ b/src/utils/public-route.js
@@ -1,16 +1,16 @@
-import React from 'react';
-import { Route } from 'react-router-dom';
+// import React from 'react';
+// import { Route } from 'react-router-dom';
 
-/**
- * @param {function|object} Component React component to render
- * @param {boolean} authed describes user auth status
- * @param {*} rest any additional parameters
- */
-export default ({ component: Component, authed, ...rest }) => (
-    <Route
-        {...rest}
-        render={(props) => authed === false
-        ? <Component {...props} />
-        : <Redirect to='/dashboard' />}
-    />
-);
+// /**
+//  * @param {function|object} Component React component to render
+//  * @param {boolean} authed describes user auth status
+//  * @param {*} rest any additional parameters
+//  */
+// export default ({ component: Component, authed, ...rest }) => (
+//     <Route
+//         {...rest}
+//         render={(props) => authed === false
+//         ? <Component {...props} />
+//         : <Redirect to='/dashboard' />}
+//     />
+// );


### PR DESCRIPTION
(where `state` refers to `store.state.auth`)

New authentication flow:
- Sign in with provider
- Get account data (OAuth/FB handles this)
- Dispatch `SIGN_IN_SUCCESS` 
  - Sets `state.authenticated` => `true`
  - Sets `state.user` => OAuth provided user data
- If `state.user.metadata.lastLogin === state.user.metadata.createdAt` User is new
  - Add public user data (`{ displayName, lifetimeScore, currentGame }`) to FB user tree
  - Dispatch `SETUP_NEW_USER_SUCCESS`
- Get user profile
  - Gets reference to FB user `user/AUTHENTICATED_USER_ID`
  - Dispatch `SET_USER_PROFILE_SUCCESS`
    - Sets `state.profile` => public user data from FB entry for authenticated user (created with `SETUP_NEW_USER_SUCCESS`)
  - Watch user profile for changes
    - Create reference to user entry
    - Create callback reference for `child_changed`
    - Dispatch `WATCH_USER_PROFILE_SUCCESS`
      - Sets `state.updateProfileCallback` => profile callback reference created in previous action

New sign out flow:
- Stop watching user profile for changes
  - Get reference to previously created `state.updateProfileCallback`
  - Remove listener with `ref.off('child_changed', state.updateProfileCallback)`
  - Dispatch `UNWATCH_USER_PROFILE_SUCCESS`
- Sign out with provider (OAuth/FB handles this)
- Dispatch `SIGN_OUT_SUCCESS`

